### PR TITLE
Add GitHub Actions workflow for automatic deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - code
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Gatsby site
+        run: yarn build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: master


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automatically build the Gatsby site and push the output to the master branch whenever there are changes pushed to the code branch.

Changes made:
- Added `.github/workflows/deploy.yml` which configures a GitHub Actions workflow.
- Configured to use `.nvmrc` for node versioning to ensure it matches the local development environment.
- Uses `peaceiris/actions-gh-pages@v3` to automate the process of publishing the `public` directory to the `master` branch using the `GITHUB_TOKEN`.

---
*PR created automatically by Jules for task [6876035638991462961](https://jules.google.com/task/6876035638991462961) started by @piyushchandra357*